### PR TITLE
Add relation `ceph-mon:client` and create ceph pools when relation is…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ Once the deployment settled, We can add `ceph-csi`
     $ juju add-relation ceph-csi ceph-mon
     
 
+## Warning: Removal
 
+When `ceph-csi` charm is removed, it will not clean up Ceph pools that were
+created when relation with `ceph-mon:client` was joined. Interface of
+`ceph-mon:client` does not seem to offer a "removal" functionality. If you
+wish to remove ceph pools, use `delete-pool` action of `ceph-mon unit`.
 
 ## Developing
 

--- a/lib/charms/ceph_csi/v0/ceph_client.py
+++ b/lib/charms/ceph_csi/v0/ceph_client.py
@@ -1,0 +1,225 @@
+# Copyright 2021 Martin Kalcok
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+
+"""Ceph client library enables to send requests to ceph broker via CephRequest class. Example of
+using CephRequest to create ceph pools from within CharmBase instance:
+
+Example:
+    request = CephRequest(self.unit, ceph_client_relation)
+    pool = CreatePoolConfig("xfs-pool", replicas=3)
+    request.add_replicated_pool(pool)
+    request.execute()
+"""
+import json
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from ops.model import Relation, Unit
+
+# The unique Charmhub library identifier, never change it
+LIBID = "b0d6eb8649ab49acb0af134a237bd612"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class RequestError(Exception):
+    """Exception that occur when sending requests to Ceph broker."""
+
+
+class CommonPoolConfig:  # pylint: disable=R0902,R0903
+    """Class that encapsulate config options that are common to requests related to ceph pools.
+
+    More specific configs, like CreatePoolConfig can inherit from this class so they can avoid
+    enumerating long list of common attributes.
+    """
+
+    OP: str = ""  # Operation name must be overriden in child classes.
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize Common config pool.
+
+        This method takes following attributes as parameters:
+
+        :param app_name: Tag pool with application name. Note that there is certain protocols
+                         emerging upstream with regard to meaningful application names to use.
+                         Examples are 'rbd' and 'rgw'.
+        :type app_name: Optional[str]
+        :param compression_algorithm: Compressor to use, one of: ('lz4', 'snappy', 'zlib', 'zstd')
+        :type compression_algorithm: Optional[str]
+        :param compression_mode: When to compress data, one of: ('none', 'passive', 'aggressive',
+                                 'force')
+        :type compression_mode: Optional[str]
+        :param compression_required_ratio: Minimum compression ratio for data chunk, if the
+                                           requested ratio is not achieved the compressed version
+                                           will be thrown away and the original stored.
+        :type compression_required_ratio: Optional[float]
+        :param compression_min_blob_size: Chunks smaller than this are never compressed
+                                          (unit: bytes).
+        :type compression_min_blob_size: Optional[int]
+        :param compression_min_blob_size_hdd: Chunks smaller than this are not compressed when
+                                              destined to rotational media (unit: bytes).
+        :type compression_min_blob_size_hdd: Optional[int]
+        :param compression_min_blob_size_ssd: Chunks smaller than this are not compressed when
+                                              destined to flash media (unit: bytes).
+        :type compression_min_blob_size_ssd: Optional[int]
+        :param compression_max_blob_size: Chunks larger than this are broken into
+                                          N * compression_max_blob_size chunks before being
+                                          compressed (unit: bytes).
+        :type compression_max_blob_size: Optional[int]
+        :param compression_max_blob_size_hdd: Chunks larger than this are broken into
+                                              N * compression_max_blob_size_hdd chunks before
+                                              being compressed when destined for rotational media
+                                              (unit: bytes)
+        :type compression_max_blob_size_hdd: Optional[int]
+        :param compression_max_blob_size_ssd: Chunks larger than this are broken into
+                                              N * compression_max_blob_size_ssd chunks before
+                                              being compressed when destined for flash media
+                                              (unit: bytes).
+        :type compression_max_blob_size_ssd: Optional[int]
+        :param group: Group to add pool to
+        :type group: Optional[str]
+        :param max_bytes: Maximum bytes quota to apply
+        :type max_bytes: Optional[int]
+        :param max_objects: Maximum objects quota to apply
+        :type max_objects: Optional[int]
+        :param group_namespace: Group namespace
+        :type group_namespace: Optional[str]
+        :param rbd_mirroring_mode: Pool mirroring mode used when Ceph RBD mirroring is enabled.
+        :type rbd_mirroring_mode: Optional[str]
+        :param weight: The percentage of data that is expected to be contained in the pool from
+                       the total available space on the OSDs. Used to calculate number of
+                       Placement Groups to create for pool.
+        :type weight: Optional[float]
+
+        """
+        self.app_name: Optional[str] = None
+        self.group: Optional[str] = None
+        self.max_bytes: Optional[int] = None
+        self.max_objects: Optional[int] = None
+        self.group_namespace: Optional[str] = None
+        self.rbd_mirroring_mode: str = "pool"
+        self.weight: Optional[float] = None
+        self.compression_algorithm: Optional[str] = None
+        self.compression_mode: Optional[str] = None
+        self.compression_required_ratio: Optional[float] = None
+        self.compression_min_blob_size: Optional[int] = None
+        self.compression_min_blob_size_hdd: Optional[int] = None
+        self.compression_min_blob_size_ssd: Optional[int] = None
+        self.compression_max_blob_size: Optional[int] = None
+        self.compression_max_blob_size_hdd: Optional[int] = None
+        self.compression_max_blob_size_ssd: Optional[int] = None
+
+        for key, value in kwargs.items():
+            _ = self.__getattribute__(key)  # Ensure that key is valid attribute
+            self.__setattr__(key, value)
+
+    def to_json(self) -> Dict[str, str]:
+        """Serialize config data into json (dict)."""
+        output = {"op": self.OP}
+        for attribute, value in vars(self).items():
+            json_key = attribute.replace("_", "-")
+            output[json_key] = value
+
+        return output
+
+
+class CreatePoolConfig(CommonPoolConfig):  # pylint: disable=R0903
+    """This class encapsulates config data required by ceph broker to create Ceph pool."""
+
+    OP = "create-pool"
+
+    def __init__(
+        self, name: str, replicas: int = 3, pg_num: Optional[int] = None, **kwargs: Any
+    ) -> None:
+        """Initialize config to create ceph pool.
+
+        :param name: Name of the pool.
+            :param replicas: How many times should be objects in this pool replicated.
+        :param pg_num: Request specific number of Placement Groups to create for the pool.
+        :param kwargs: Additional config options. See attributes of CommonPoolConfig for more info
+                       about available options.
+        """
+        self.name = name
+        self.replicas = replicas
+        self.pg_num = pg_num
+        super().__init__(**kwargs)
+
+    def to_json(self) -> Dict[str, str]:
+        output = super().to_json()
+        # parameter pg_num needs to be renamed since, unlike every other, it's expected with
+        # underscore, not dash
+        output["pg_num"] = output.pop("pg-num")
+        return output
+
+
+class CephRequest:
+    """This class represents single request for ceph-broker.
+
+    Request is executed by setting appropriate data in the relation with ceph-mon application.
+
+    Note: More than one operation (ops) can be requested at once. For example, one request can
+    create multiple ceph pools.
+    """
+
+    def __init__(self, unit: Unit, client_relation: Relation, id_: str = "", api_version: int = 1):
+        """
+        Initialize CephRequest.
+
+        :param unit: Juju unit from which the request originates.
+        :param client_relation: Instance of relation with ceph-mon application.
+        :param id_: (Optional) Request ID. If not supplied, new random uuid will be generated.
+        :param api_version: Version of ceph-broker API. default=1.
+        """
+        self.unit = unit
+        self.relation = client_relation
+        self.api_version = api_version
+        self.uuid = id_ or str(uuid4())
+        self._ops: List[Dict] = []
+
+    @property
+    def ops(self) -> List[Dict]:
+        """List of operations contained in this request."""
+        return self._ops
+
+    @property
+    def request(self) -> Dict:
+        """Return whole request serialized as a dict."""
+        return {"api-version": self.api_version, "request-id": self.uuid, "ops": self.ops}
+
+    def add_op(self, op_data: Dict) -> None:
+        """Add new operation to the request.
+
+        Operations are de-duplicated and no action is done if same operation is already part this
+        request.
+
+        :param op_data: Operation that will be requested from the ceph broker, serialized as dict.
+        """
+        if op_data not in self.ops:
+            self.ops.append(op_data)
+
+    def execute(self) -> None:
+        """Send request to ceph-broker.
+
+        Communication with ceph-broker is done via juju relation with ceph-mon application. Request
+        is sent by storing it in the relation data.
+        """
+        if not self.ops:
+            raise RequestError(
+                "Can not execute request without specifying operations ({})".format(self.uuid)
+            )
+        self.relation.data[self.unit]["broker_req"] = json.dumps(self.request)
+
+    def add_replicated_pool(self, config: CreatePoolConfig) -> None:
+        """Add operation that creates new replicated ceph pool to this request.
+
+        :param config: Specification of the ceph pool parameters.
+        :return: None
+        """
+        self.add_op(config.to_json())

--- a/lib/charms/ceph_csi/v0/ceph_client.py
+++ b/lib/charms/ceph_csi/v0/ceph_client.py
@@ -126,10 +126,8 @@ class CommonPoolConfig:  # pylint: disable=R0902,R0903
 
     def to_json(self) -> Dict[str, Any]:
         """Serialize config data into json (dict)."""
-        output = {"op": self.OP}
-        for attribute, value in vars(self).items():
-            json_key = attribute.replace("_", "-")
-            output[json_key] = value
+        output = {attribute.replace("_", "-"): value for attribute, value in vars(self).items()}
+        output["op"] = self.OP
 
         return output
 
@@ -225,6 +223,7 @@ class CephRequest:
             raise RequestError(
                 "Can not execute request without specifying operations ({})".format(self.uuid)
             )
+
         serialized_request = json.dumps(self.request)
         logger.info("Sending request %s to Ceph broker.", self.uuid)
         logger.debug("Request %s details: %s", self.uuid, serialized_request)

--- a/lib/charms/ceph_csi/v0/ceph_client.py
+++ b/lib/charms/ceph_csi/v0/ceph_client.py
@@ -37,7 +37,7 @@ class RequestError(Exception):
     """Exception that occur when sending requests to Ceph broker."""
 
 
-class CommonPoolConfig:  # pylint: disable=R0902,R0903
+class CommonPoolConfig:  # pylint: disable=R0902,R0903,R0913,R0914
     """Class that encapsulate config options that are common to requests related to ceph pools.
 
     More specific configs, like CreatePoolConfig can inherit from this class so they can avoid
@@ -46,7 +46,25 @@ class CommonPoolConfig:  # pylint: disable=R0902,R0903
 
     OP = ""  # Operation name must be overriden in child classes.
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        app_name: Optional[str] = None,
+        group: Optional[str] = None,
+        max_bytes: Optional[int] = None,
+        max_objects: Optional[int] = None,
+        group_namespace: Optional[str] = None,
+        rbd_mirroring_mode: str = "pool",
+        weight: Optional[float] = None,
+        compression_algorithm: Optional[str] = None,
+        compression_mode: Optional[str] = None,
+        compression_required_ratio: Optional[float] = None,
+        compression_min_blob_size: Optional[int] = None,
+        compression_min_blob_size_hdd: Optional[int] = None,
+        compression_min_blob_size_ssd: Optional[int] = None,
+        compression_max_blob_size: Optional[int] = None,
+        compression_max_blob_size_hdd: Optional[int] = None,
+        compression_max_blob_size_ssd: Optional[int] = None,
+    ) -> None:
         """Initialize Common config pool.
 
         This method takes following attributes as parameters:
@@ -54,75 +72,54 @@ class CommonPoolConfig:  # pylint: disable=R0902,R0903
         :param app_name: Tag pool with application name. Note that there is certain protocols
                          emerging upstream with regard to meaningful application names to use.
                          Examples are 'rbd' and 'rgw'.
-        :type app_name: Optional[str]
         :param compression_algorithm: Compressor to use, one of: ('lz4', 'snappy', 'zlib', 'zstd')
-        :type compression_algorithm: Optional[str]
         :param compression_mode: When to compress data, one of: ('none', 'passive', 'aggressive',
                                  'force')
-        :type compression_mode: Optional[str]
         :param compression_required_ratio: Minimum compression ratio for data chunk, if the
                                            requested ratio is not achieved the compressed version
                                            will be thrown away and the original stored.
-        :type compression_required_ratio: Optional[float]
         :param compression_min_blob_size: Chunks smaller than this are never compressed
                                           (unit: bytes).
-        :type compression_min_blob_size: Optional[int]
         :param compression_min_blob_size_hdd: Chunks smaller than this are not compressed when
                                               destined to rotational media (unit: bytes).
-        :type compression_min_blob_size_hdd: Optional[int]
         :param compression_min_blob_size_ssd: Chunks smaller than this are not compressed when
                                               destined to flash media (unit: bytes).
-        :type compression_min_blob_size_ssd: Optional[int]
         :param compression_max_blob_size: Chunks larger than this are broken into
                                           N * compression_max_blob_size chunks before being
                                           compressed (unit: bytes).
-        :type compression_max_blob_size: Optional[int]
         :param compression_max_blob_size_hdd: Chunks larger than this are broken into
                                               N * compression_max_blob_size_hdd chunks before
                                               being compressed when destined for rotational media
                                               (unit: bytes)
-        :type compression_max_blob_size_hdd: Optional[int]
         :param compression_max_blob_size_ssd: Chunks larger than this are broken into
                                               N * compression_max_blob_size_ssd chunks before
                                               being compressed when destined for flash media
                                               (unit: bytes).
-        :type compression_max_blob_size_ssd: Optional[int]
         :param group: Group to add pool to
-        :type group: Optional[str]
         :param max_bytes: Maximum bytes quota to apply
-        :type max_bytes: Optional[int]
         :param max_objects: Maximum objects quota to apply
-        :type max_objects: Optional[int]
         :param group_namespace: Group namespace
-        :type group_namespace: Optional[str]
         :param rbd_mirroring_mode: Pool mirroring mode used when Ceph RBD mirroring is enabled.
-        :type rbd_mirroring_mode: Optional[str]
         :param weight: The percentage of data that is expected to be contained in the pool from
                        the total available space on the OSDs. Used to calculate number of
                        Placement Groups to create for pool.
-        :type weight: Optional[float]
-
         """
-        self.app_name = None
-        self.group = None
-        self.max_bytes = None
-        self.max_objects = None
-        self.group_namespace = None
-        self.rbd_mirroring_mode = "pool"
-        self.weight = None
-        self.compression_algorithm = None
-        self.compression_mode = None
-        self.compression_required_ratio = None
-        self.compression_min_blob_size = None
-        self.compression_min_blob_size_hdd = None
-        self.compression_min_blob_size_ssd = None
-        self.compression_max_blob_size = None
-        self.compression_max_blob_size_hdd = None
-        self.compression_max_blob_size_ssd = None
-
-        for key, value in kwargs.items():
-            _ = self.__getattribute__(key)  # Ensure that key is valid attribute
-            self.__setattr__(key, value)
+        self.app_name = app_name
+        self.group = group
+        self.max_bytes = max_bytes
+        self.max_objects = max_objects
+        self.group_namespace = group_namespace
+        self.rbd_mirroring_mode = rbd_mirroring_mode
+        self.weight = weight
+        self.compression_algorithm = compression_algorithm
+        self.compression_mode = compression_mode
+        self.compression_required_ratio = compression_required_ratio
+        self.compression_min_blob_size = compression_min_blob_size
+        self.compression_min_blob_size_hdd = compression_min_blob_size_hdd
+        self.compression_min_blob_size_ssd = compression_min_blob_size_ssd
+        self.compression_max_blob_size = compression_max_blob_size
+        self.compression_max_blob_size_hdd = compression_max_blob_size_hdd
+        self.compression_max_blob_size_ssd = compression_max_blob_size_ssd
 
     def to_json(self) -> Dict[str, Any]:
         """Serialize config data into json (dict)."""

--- a/lib/charms/ceph_csi/v0/ceph_client.py
+++ b/lib/charms/ceph_csi/v0/ceph_client.py
@@ -40,7 +40,7 @@ class CommonPoolConfig:  # pylint: disable=R0902,R0903
     enumerating long list of common attributes.
     """
 
-    OP: str = ""  # Operation name must be overriden in child classes.
+    OP = ""  # Operation name must be overriden in child classes.
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize Common config pool.
@@ -99,28 +99,28 @@ class CommonPoolConfig:  # pylint: disable=R0902,R0903
         :type weight: Optional[float]
 
         """
-        self.app_name: Optional[str] = None
-        self.group: Optional[str] = None
-        self.max_bytes: Optional[int] = None
-        self.max_objects: Optional[int] = None
-        self.group_namespace: Optional[str] = None
-        self.rbd_mirroring_mode: str = "pool"
-        self.weight: Optional[float] = None
-        self.compression_algorithm: Optional[str] = None
-        self.compression_mode: Optional[str] = None
-        self.compression_required_ratio: Optional[float] = None
-        self.compression_min_blob_size: Optional[int] = None
-        self.compression_min_blob_size_hdd: Optional[int] = None
-        self.compression_min_blob_size_ssd: Optional[int] = None
-        self.compression_max_blob_size: Optional[int] = None
-        self.compression_max_blob_size_hdd: Optional[int] = None
-        self.compression_max_blob_size_ssd: Optional[int] = None
+        self.app_name = None
+        self.group = None
+        self.max_bytes = None
+        self.max_objects = None
+        self.group_namespace = None
+        self.rbd_mirroring_mode = "pool"
+        self.weight = None
+        self.compression_algorithm = None
+        self.compression_mode = None
+        self.compression_required_ratio = None
+        self.compression_min_blob_size = None
+        self.compression_min_blob_size_hdd = None
+        self.compression_min_blob_size_ssd = None
+        self.compression_max_blob_size = None
+        self.compression_max_blob_size_hdd = None
+        self.compression_max_blob_size_ssd = None
 
         for key, value in kwargs.items():
             _ = self.__getattribute__(key)  # Ensure that key is valid attribute
             self.__setattr__(key, value)
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> Dict[str, Any]:
         """Serialize config data into json (dict)."""
         output = {"op": self.OP}
         for attribute, value in vars(self).items():
@@ -151,7 +151,7 @@ class CreatePoolConfig(CommonPoolConfig):  # pylint: disable=R0903
         self.pg_num = pg_num
         super().__init__(**kwargs)
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> Dict[str, Any]:
         output = super().to_json()
         # parameter pg_num needs to be renamed since, unlike every other, it's expected with
         # underscore, not dash
@@ -181,19 +181,19 @@ class CephRequest:
         self.relation = client_relation
         self.api_version = api_version
         self.uuid = id_ or str(uuid4())
-        self._ops: List[Dict] = []
+        self._ops = []
 
     @property
-    def ops(self) -> List[Dict]:
+    def ops(self) -> List[Dict[str, Any]]:
         """List of operations contained in this request."""
         return self._ops
 
     @property
-    def request(self) -> Dict:
+    def request(self) -> Dict[str, Any]:
         """Return whole request serialized as a dict."""
         return {"api-version": self.api_version, "request-id": self.uuid, "ops": self.ops}
 
-    def add_op(self, op_data: Dict) -> None:
+    def add_op(self, op_data: Dict[str, Any]) -> None:
         """Add new operation to the request.
 
         Operations are de-duplicated and no action is done if same operation is already part this

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,8 +12,10 @@ series:
   - bionic
   - xenial
 requires:
-  ceph:
+  ceph-admin:
     interface: ceph-admin
+  ceph-client:
+    interface: ceph-client
   kubernetes:
     interface: juju-info
     scope: container

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,8 @@ warn_unused_ignores = True
 warn_unused_configs = True
 warn_unreachable = True
 disallow_untyped_defs = True
+; Due to python 3.5 support we can't enforce variable type annotations
+disable_error_code = var-annotated
 
 # Ignore unsupported imports
 [mypy-kubernetes.*]

--- a/tests/unit/test_lib_charms_ceph_csi_v0_ceph_client.py
+++ b/tests/unit/test_lib_charms_ceph_csi_v0_ceph_client.py
@@ -1,0 +1,203 @@
+# Copyright 2021 Martin Kalcok
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+"""Tests for library lib.charms.ceph_csi.v0.ceph_client."""
+
+import json
+import unittest
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from charms.ceph_csi.v0.ceph_client import (
+    CephRequest,
+    CommonPoolConfig,
+    CreatePoolConfig,
+    RequestError,
+)
+
+
+class TestCommonPoolConfig(unittest.TestCase):
+    """Tests for lib.charms.ceph_csi.v0.ceph_client.CommonPoolConfig class."""
+
+    EXPECTED_ATTRIBUTES = {  # mapping of expected attributes to their json representation
+        "app_name": "app-name",
+        "group": "group",
+        "max_bytes": "max-bytes",
+        "max_objects": "max-objects",
+        "group_namespace": "group-namespace",
+        "rbd_mirroring_mode": "rbd-mirroring-mode",
+        "weight": "weight",
+        "compression_algorithm": "compression-algorithm",
+        "compression_mode": "compression-mode",
+        "compression_required_ratio": "compression-required-ratio",
+        "compression_min_blob_size": "compression-min-blob-size",
+        "compression_min_blob_size_hdd": "compression-min-blob-size-hdd",
+        "compression_min_blob_size_ssd": "compression-min-blob-size-ssd",
+        "compression_max_blob_size": "compression-max-blob-size",
+        "compression_max_blob_size_hdd": "compression-max-blob-size-hdd",
+        "compression_max_blob_size_ssd": "compression-max-blob-size-ssd",
+    }
+
+    def test_expected_attributes(self):
+        """Test that CommonPoolConfig instance has expected attributes."""
+        config = CommonPoolConfig()
+        instance_attributes = vars(config).keys()
+
+        self.assertEqual(instance_attributes, self.EXPECTED_ATTRIBUTES.keys())
+
+    def test_attribute_assignment(self):
+        """Test that initialization of every expected CommonPoolConfig attribute works."""
+        args = {attr: uuid4() for attr in self.EXPECTED_ATTRIBUTES}
+
+        config = CommonPoolConfig(**args)
+
+        for key, value in args.items():
+            self.assertEqual(config.__getattribute__(key), value)
+
+    def test_raise_on_unknown_attribute(self):
+        """Test that AttributeError is raised if unexpected attribute is passed to the __init__."""
+        with self.assertRaises(AttributeError):
+            _ = CommonPoolConfig(foo="bar")
+
+    def test_to_json_serialization(self):
+        """Test that to_json() serialization returns expected dictionary.
+
+        Keys in the returned dictionary should use hyphenated variable names as expected by ceph
+        broker.
+        """
+        expected_output = {"op": CommonPoolConfig.OP}  # Operation name is explicitly inserted
+        init_arguments = {}
+
+        for class_attribute, json_key in self.EXPECTED_ATTRIBUTES.items():
+            value = uuid4()
+            expected_output[json_key] = value
+            init_arguments[class_attribute] = value
+
+        config = CommonPoolConfig(**init_arguments)
+
+        self.assertEqual(config.to_json(), expected_output)
+
+
+class TestCreatePoolConfig(unittest.TestCase):
+    """Tests for lib.charms.ceph_csi.v0.ceph_client.CreatePoolConfig class."""
+
+    COMMON_ATTRIBUTES = TestCommonPoolConfig.EXPECTED_ATTRIBUTES.copy()
+    SPECIFIC_ATTRIBUTES = {
+        "name": "name",
+        "replicas": "replicas",
+        "pg_num": "pg_num",  # This is not a typo, pg_num is expected with underscore in json too.
+    }
+
+    @property
+    def expected_attributes(self) -> dict:
+        """Return all expected attributes of CreateCephPool instance,"""
+        return {**self.COMMON_ATTRIBUTES, **self.SPECIFIC_ATTRIBUTES}
+
+    def test_expected_attributes(self):
+        """Test that CreateCephPool instance has expected attributes."""
+        pool = CreatePoolConfig("foo")
+        instance_attributes = vars(pool).keys()
+
+        self.assertEqual(instance_attributes, self.expected_attributes.keys())
+
+    def test_json_serialization(self):
+        """Test that to_json() serialization returns expected dictionary.
+
+        Keys in the returned dictionary should use hyphenated variable names as expected by ceph
+        broker. Only exception is "pg_num" key which is expected with underscore.
+        """
+        expected_output = {"op": CreatePoolConfig.OP}
+        init_arguments = {}
+
+        for class_attribute, json_key in self.expected_attributes.items():
+            value = uuid4()
+            expected_output[json_key] = value
+            init_arguments[class_attribute] = value
+
+        pool = CreatePoolConfig(**init_arguments)
+        self.assertEqual(pool.to_json(), expected_output)
+
+
+class TestCephRequest(unittest.TestCase):
+    """Tests for lib.charms.ceph_csi.v0.ceph_client.CephRequest class."""
+
+    def test_id_generation(self):
+        """Test that if not supplied, new UUIDv4 is generated as request ID."""
+        request_1 = CephRequest(MagicMock(), MagicMock())
+        request_2 = CephRequest(MagicMock(), MagicMock())
+        expected_uuid_len = len(str(uuid4()))
+
+        self.assertNotEqual(request_1.uuid, request_2.uuid)
+        self.assertIsInstance(request_1.uuid, str)
+        self.assertEqual(len(request_1.uuid), expected_uuid_len)
+
+    def test_add_operation(self):
+        """Test adding operation to the request."""
+        operation = {"name": "foo", "data": "bar"}
+        request = CephRequest(MagicMock(), MagicMock())
+
+        request.add_op(operation)
+
+        self.assertEqual(len(request.ops), 1)
+        self.assertEqual(request.ops[0], operation)
+
+        # Adding same operation second time should not have any effect
+        request.add_op(operation)
+        self.assertEqual(len(request.ops), 1)
+
+        # New operation can be added
+        new_op = {"name": "baz", "data": None}
+        request.add_op(new_op)
+        self.assertEqual(len(request.ops), 2)
+        self.assertIn(operation, request.ops)
+        self.assertIn(new_op, request.ops)
+
+    def test_serialization(self):
+        """Test that `request` attribute of CephRequest returns expected dictionary."""
+        api_version = 1
+        id_ = str(uuid4())
+        operation = {"name": "foo", "data": "bar"}
+
+        expected_output = {"api-version": api_version, "request-id": id_, "ops": [operation]}
+
+        request = CephRequest(MagicMock(), MagicMock(), id_, api_version)
+        request.add_op(operation)
+
+        self.assertEqual(request.request, expected_output)
+
+    def test_execute(self):
+        """Test that execute() method stores expected data into the relation with ceph-mon."""
+        relation = MagicMock()
+        unit = "cph-csi/0"
+        relation.data = {unit: {}}
+        api_version = 1
+        id_ = str(uuid4())
+        operation = {"name:": "bar", "data": "foo"}
+
+        expected_output = json.dumps(
+            {"api-version": api_version, "request-id": id_, "ops": [operation]}
+        )
+        request = CephRequest(unit, relation, id_, api_version)
+        request.add_op(operation)
+
+        request.execute()
+
+        self.assertEqual(relation.data[unit]["broker_req"], expected_output)
+
+    def test_execute_raises_on_empty_ops(self):
+        """Test that executing request without operations raises exception."""
+        request = CephRequest(MagicMock(), MagicMock())
+
+        with self.assertRaises(RequestError):
+            request.execute()
+
+    def test_add_replicated_pool(self):
+        """Test that add_replicated_pool() method stores expected data in the `ops` list."""
+        pool = CreatePoolConfig("test-pool")
+        request = CephRequest(MagicMock(), MagicMock())
+
+        request.add_replicated_pool(pool)
+
+        self.assertEqual(len(request.ops), 1)
+        self.assertEqual(request.ops[0], pool.to_json())

--- a/tests/unit/test_lib_charms_ceph_csi_v0_ceph_client.py
+++ b/tests/unit/test_lib_charms_ceph_csi_v0_ceph_client.py
@@ -55,11 +55,6 @@ class TestCommonPoolConfig(unittest.TestCase):
         for key, value in args.items():
             self.assertEqual(config.__getattribute__(key), value)
 
-    def test_raise_on_unknown_attribute(self):
-        """Test that AttributeError is raised if unexpected attribute is passed to the __init__."""
-        with self.assertRaises(AttributeError):
-            _ = CommonPoolConfig(foo="bar")
-
     def test_to_json_serialization(self):
         """Test that to_json() serialization returns expected dictionary.
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ requires =
 
 [testenv]
 setenv =
-    PYTHONPATH={toxinidir}/src
+    PYTHONPATH={toxinidir}/src:{toxinidir}/lib
 passenv =
     HTTP_PROXY
     HTTPS_PROXY
@@ -16,26 +16,26 @@ deps = -r{toxinidir}/requirements-dev.txt
 [testenv:lint]
 basepython = python3
 commands =
-    flake8 {toxinidir}/src/ {toxinidir}/tests/
-    pylint {toxinidir}/src/
+    flake8 {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
+    pylint {toxinidir}/src/ {toxinidir}/lib/
     pylint {toxinidir}/tests/ --disable=W0212,R0801,R0201
-    mypy {toxinidir}/src/
-    black -l 99 --check {toxinidir}/src/ {toxinidir}/tests/
-    isort --check {toxinidir}/src/ {toxinidir}/tests/
+    mypy --namespace-packages {toxinidir}/src/ {toxinidir}/lib/
+    black -l 99 --check {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
+    isort --check {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
 
 [testenv:unit]
 basepython = python3
 deps = -r{toxinidir}/requirements-test.txt
 commands =
-    coverage run --source={toxinidir}/src -m unittest discover {toxinidir}/tests/unit/
+    coverage run --source={toxinidir}/src,{toxinidir}/lib -m unittest discover {toxinidir}/tests/unit/
     coverage report -m --fail-under=100
 
 [testenv:format-code]
 envdir = {toxworkdir}/lint
 basepython = python3
 commands =
-    black -l 99 {toxinidir}/src/ {toxinidir}/tests/
-    isort {toxinidir}/src/ {toxinidir}/tests/
+    black -l 99 {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
+    isort {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
 
 [isort]
 line_length=99


### PR DESCRIPTION
Added library that partially implements functionality of [charm-interface-ceph-client](https://opendev.org/openstack/charm-interface-ceph-client), namely the ability to create Ceph pools.

This library is then used to create `xfs-pool` and `ext4-pool` when `ceph-mon:client` relation is joined.