### PR TITLE
Functional tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 max-line-length = 99
 ignore = W503
 select: E,W,F,C,N
+per-file-ignores = __init__.py:F401
 exclude:
   venv
   .git

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ The Python operator framework includes a very nice harness for testing
 operator behaviour without full deployment. To execute unit tests, run:
 
     $ tox -e unit
+    
+This charm contains also functional tests which fully deploy `ceph-csi` charm 
+along with `kubernets` and `ceph` cluster to test its functionality in real
+environment. There are few ways to run functional tests
+
+    $ tox -e func                          # Deploys new juju model and runs tests
+    $ tox -e func -- --model <model_name>  # Runs tests against existing model
+    $ tox -e func -- --keep-models         # Does not tear down model after tests are done (usefull for debuging failing tests )
+
+
+**__NOTE:__** If the environment which runs functional tests is behind the http
+proxy, you must export `TEST_HTTPS_PROXY` environment variable. Otherwise the
+kubernetes might have problem with fetching of docker images. Example:
+
+    $ export TEST_HTTPS_PROXY=http://10.0.0.1:3128
+    $ tox -e func
 
 [1]: https://charmhub.io/containers-kubernetes-master
 [2]: https://charmhub.io/charmed-kubernetes

--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ operator behaviour without full deployment. To execute unit tests, run:
     $ tox -e unit
     
 This charm contains also functional tests which fully deploy `ceph-csi` charm 
-along with `kubernets` and `ceph` cluster to test its functionality in real
-environment. There are few ways to run functional tests
+along with `kubernetes` and `ceph` cluster to test its functionality in a real
+environment. There are a few ways to run functional tests
 
     $ tox -e func                          # Deploys new juju model and runs tests
     $ tox -e func -- --model <model_name>  # Runs tests against existing model
     $ tox -e func -- --keep-models         # Does not tear down model after tests are done (usefull for debuging failing tests )
 
 
-**__NOTE:__** If the environment which runs functional tests is behind the http
-proxy, you must export `TEST_HTTPS_PROXY` environment variable. Otherwise the
-kubernetes might have problem with fetching of docker images. Example:
+**__NOTE:__** If the environment which runs functional tests is behind a http
+proxy, you must export `TEST_HTTPS_PROXY` environment variable. Otherwise
+Kubernetes might have problem fetching docker images. Example:
 
     $ export TEST_HTTPS_PROXY=http://10.0.0.1:3128
     $ tox -e func

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 coverage
+pytest
+pytest-operator

--- a/src/charm.py
+++ b/src/charm.py
@@ -298,13 +298,13 @@ class CephCsiCharm(CharmBase):
             return
 
         unit_data = event.relation.data[event.unit]
-        expected_data = (
+        expected_relation_keys = (
             "fsid",
             "key",
             "mon_hosts",
         )
 
-        for relation_key in expected_data:
+        for relation_key in expected_relation_keys:
             self._stored.ceph_data[relation_key] = unit_data.get(relation_key)
 
         missing_data = [key for key, value in self._stored.ceph_data.items() if value is None]

--- a/tests/functional/bundle.yaml
+++ b/tests/functional/bundle.yaml
@@ -1,0 +1,131 @@
+description: A minimal two-machine Kubernetes cluster, appropriate for development.
+series: focal
+machines:
+  '0':
+    constraints: cores=2 mem=4G root-disk=16G
+    series: focal
+  '1':
+    constraints: cores=2 mem=4G root-disk=16G
+    series: focal
+  '2':
+    constraints: cores=4 mem=4G root-disk=16G
+    series: focal
+  '3':
+    constraints: cores=2
+    series: bionic
+  '4':
+    constraints: cores=2
+    series: bionic
+  '5':
+    constraints: cores=2
+    series: bionic
+applications:
+  containerd:
+    charm: cs:~containers/containerd-160
+    resources: {}
+  easyrsa:
+    charm: cs:~containers/easyrsa-408
+    num_units: 1
+    resources:
+      easyrsa: 5
+    to:
+    - lxd:3
+  etcd:
+    charm: cs:~containers/etcd-620
+    num_units: 1
+    options:
+      channel: 3.4/stable
+    resources:
+      core: 0
+      etcd: 3
+      snapshot: 0
+    to:
+    - '0'
+  flannel:
+    charm: cs:~containers/flannel-584
+    resources:
+      flannel-amd64: 844
+      flannel-arm64: 841
+      flannel-s390x: 828
+  kubernetes-master:
+    charm: cs:~containers/kubernetes-master-1051
+    expose: true
+    num_units: 2
+    options:
+      channel: 1.22/stable
+      allow-privileged: "true"
+    resources:
+      cdk-addons: 0
+      core: 0
+      kube-apiserver: 0
+      kube-controller-manager: 0
+      kube-proxy: 0
+      kube-scheduler: 0
+      kubectl: 0
+    to:
+    - '0'
+    - '1'
+  kubernetes-worker:
+    charm: cs:~containers/kubernetes-worker-801
+    expose: true
+    num_units: 1
+    options:
+      channel: 1.22/stable
+    resources:
+      cni-amd64: 880
+      cni-arm64: 871
+      cni-s390x: 883
+      core: 0
+      kube-proxy: 0
+      kubectl: 0
+      kubelet: 0
+    to:
+    - '2'
+  ceph-mon:
+    charm: cs:ceph-mon-58
+    num_units: 3
+    series: bionic
+    to:
+    - lxd:3
+    - lxd:4
+    - lxd:5
+  ceph-osd:
+    charm: cs:ceph-osd-312
+    num_units: 3
+    options:
+      osd-devices: /srv/osd
+    series: bionic
+    to:
+    - '3'
+    - '4'
+    - '5'
+  ceph-csi:
+    charm: {{ master_charm }}
+
+relations:
+- - kubernetes-master:kube-control
+  - kubernetes-worker:kube-control
+- - kubernetes-master:certificates
+  - easyrsa:client
+- - kubernetes-master:etcd
+  - etcd:db
+- - kubernetes-worker:certificates
+  - easyrsa:client
+- - etcd:certificates
+  - easyrsa:client
+- - flannel:etcd
+  - etcd:db
+- - flannel:cni
+  - kubernetes-master:cni
+- - flannel:cni
+  - kubernetes-worker:cni
+- - containerd:containerd
+  - kubernetes-worker:container-runtime
+- - containerd:containerd
+  - kubernetes-master:container-runtime
+- - ceph-osd
+  - ceph-mon
+- - ceph-csi
+  - kubernetes-master
+- - ceph-csi
+  - ceph-mon

--- a/tests/functional/bundle.yaml
+++ b/tests/functional/bundle.yaml
@@ -23,6 +23,10 @@ applications:
   containerd:
     charm: cs:~containers/containerd-160
     resources: {}
+    {% if https_proxy %}
+    options:
+      https_proxy: {{ https_proxy }}
+    {% endif %}
   easyrsa:
     charm: cs:~containers/easyrsa-408
     num_units: 1
@@ -95,6 +99,9 @@ applications:
     options:
       osd-devices: /srv/osd
     series: bionic
+    storage:
+      osd-devices: 1G,2
+      osd-journals: 1G,1
     to:
     - '3'
     - '4'
@@ -128,4 +135,6 @@ relations:
 - - ceph-csi
   - kubernetes-master
 - - ceph-csi
-  - ceph-mon
+  - ceph-mon:client
+- - ceph-csi
+  - ceph-mon:admin

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Martin Kalcok
+# See LICENSE file for licensing details.
+"""Pytest fixtures for functional tests."""
+#  pylint: disable=W0621
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+from kubernetes import client, config
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def namespace() -> str:
+    """Return namespace used for functional tests."""
+    return "default"
+
+
+@pytest.fixture(scope="module")
+async def kube_config(ops_test: OpsTest) -> Path:
+    """Return path to the kube config of the tested Kubernetes cluster.
+
+    Config file is fetched from kubernetes-master unit and stored in the temporary file.
+    """
+    k8s_master = ops_test.model.applications["kubernetes-master"].units[0]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        kube_config_file = Path(tmp_dir).joinpath("kube_config")
+
+        cmd = "juju scp {}:config {}".format(k8s_master.name, kube_config_file).split()
+        return_code, _, std_err = await ops_test.run(*cmd)
+        assert return_code == 0, std_err
+        yield kube_config_file
+
+
+@pytest.fixture()
+async def cleanup_k8s(kube_config, namespace: str):
+    """Cleanup kubernetes resources created during test."""
+    yield  # act only on teardown
+    config.load_kube_config(str(kube_config))
+
+    pod_prefixes = ["read-test-ceph-", "write-test-ceph"]
+    pvc_prefix = "pvc-test-"
+    core_api = client.CoreV1Api()
+
+    for pod in core_api.list_namespaced_pod(namespace).items:
+        pod_name = pod.metadata.name
+        if any(pod_name.startswith(prefix) for prefix in pod_prefixes):
+            try:
+                logger.info("Removing Pod %s", pod_name)
+                core_api.delete_namespaced_pod(pod_name, namespace)
+            except client.ApiException as exc:
+                if exc.status != 404:
+                    raise exc
+                logger.debug("Pod %s is already removed", pod_name)
+
+    for pvc in core_api.list_namespaced_persistent_volume_claim(namespace).items:
+        pvc_name = pvc.metadata.name
+        if pvc_name.startswith(pvc_prefix):
+            try:
+                logger.info("Removing PersistentVolumeClaim %s", pvc_name)
+                core_api.delete_namespaced_persistent_volume_claim(pvc_name, namespace)
+            except client.ApiException as exc:
+                if exc.status != 404:
+                    raise exc
+                logger.debug("PersistentVolumeClaim %s is already removed.", pvc_name)

--- a/tests/functional/templates/persistent_volume.yaml.j2
+++ b/tests/functional/templates/persistent_volume.yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-test-{{ storage_class }}
+  annotations:
+   volume.beta.kubernetes.io/storage-class: {{ storage_class }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/tests/functional/templates/reading_pod.yaml.j2
+++ b/tests/functional/templates/reading_pod.yaml.j2
@@ -1,0 +1,18 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: read-test-{{ storage_class }}
+spec:
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: pvc-test-{{ storage_class }}
+      readOnly: false
+  containers:
+    - name: read-test-{{ storage_class }}
+      image: public.ecr.aws/ubuntu/ubuntu:latest
+      command: ["/bin/bash", "-c", "cat /data/juju"]
+      volumeMounts:
+      - name: shared-data
+        mountPath: /data
+  restartPolicy: Never

--- a/tests/functional/templates/reading_pod.yaml.j2
+++ b/tests/functional/templates/reading_pod.yaml.j2
@@ -10,6 +10,7 @@ spec:
       readOnly: false
   containers:
     - name: read-test-{{ storage_class }}
+      #  Amazon registry is used because we were hitting rate limits in dockerhub
       image: public.ecr.aws/ubuntu/ubuntu:latest
       command: ["/bin/bash", "-c", "cat /data/juju"]
       volumeMounts:

--- a/tests/functional/templates/writing_pod.yaml.j2
+++ b/tests/functional/templates/writing_pod.yaml.j2
@@ -10,6 +10,7 @@ spec:
       readOnly: false
   containers:
     - name: write-test-{{ storage_class }}
+      #  Amazon registry is used because we were hitting rate limits in dockerhub
       image: public.ecr.aws/ubuntu/ubuntu:latest
       command: ["/bin/bash", "-c", "echo '{{ data }}' > /data/juju"]
       volumeMounts:

--- a/tests/functional/templates/writing_pod.yaml.j2
+++ b/tests/functional/templates/writing_pod.yaml.j2
@@ -1,0 +1,18 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: write-test-{{ storage_class }}
+spec:
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: pvc-test-{{ storage_class }}
+      readOnly: false
+  containers:
+    - name: write-test-{{ storage_class }}
+      image: public.ecr.aws/ubuntu/ubuntu:latest
+      command: ["/bin/bash", "-c", "echo '{{ data }}' > /data/juju"]
+      volumeMounts:
+      - name: shared-data
+        mountPath: /data
+  restartPolicy: Never

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -2,19 +2,95 @@
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
+"""Functional tests for ceph-csi charm."""
+
+import logging
+from os import environ
+from pathlib import Path
+from uuid import uuid4
+
 import pytest
+from kubernetes import client, config, utils
 from pytest_operator.plugin import OpsTest
+from utils import render_j2_template, wait_for_pod
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_DIR = "./tests/functional/templates/"
+
+STORAGE_TEMPLATE = "persistent_volume.yaml.j2"
+READING_POD_TEMPLATE = "reading_pod.yaml.j2"
+WRITING_POD_TEMPLATE = "writing_pod.yaml.j2"
+
+SUCCESS_POD_STATE = "Succeeded"
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test):
+    """Build ceph-csi charm and deploy testing model."""
+    logger.info("Building ceph-csi charm.")
     ceph_csi_charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(ops_test.render_bundle(
-        "tests/functional/bundle.yaml", master_charm=ceph_csi_charm))
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60, check_freq=5, raise_on_error=False)
+
+    bundle_vars = {"master_charm": ceph_csi_charm}
+    proxy_settings = environ.get("TEST_HTTPS_PROXY")
+    if proxy_settings:
+        bundle_vars["https_proxy"] = proxy_settings
+
+    logger.debug("Deploying ceph-csi functional test bundle.")
+    await ops_test.model.deploy(
+        ops_test.render_bundle("tests/functional/bundle.yaml", **bundle_vars)
+    )
+    await ops_test.model.wait_for_idle(
+        wait_for_active=True, timeout=60 * 60, check_freq=5, raise_on_error=False
+    )
 
 
 async def test_active_status(ops_test: OpsTest):
+    """Test that ceph-csi charm reached the active state."""
     for unit in ops_test.model.applications["ceph-csi"].units:
         assert unit.workload_status == "active"
         assert unit.workload_status_message == "Unit is ready"
+
+
+@pytest.mark.parametrize("storage_class", ["ceph-xfs", "ceph-ext4"])
+async def test_storage_class(
+    kube_config: Path, storage_class: str, namespace: str, cleanup_k8s: None, ops_test
+):
+    """Test that ceph can be used to create persistent volume.
+
+    This test has following flow:
+      * Create PersistentVolumeClaim using one of the supported StorageClasses
+      * Create "writing_pod" that uses PersistentVolumeClaim to create file and write data to it.
+      * Create "reading_pod" that reads expected data from file in the PersistentVolumeClaim.
+    """
+    test_payload = "func-test-write-{}-{}".format(storage_class, str(uuid4()))
+
+    config.load_kube_config(str(kube_config))
+    k8s_api_client = client.ApiClient()
+    core_api = client.CoreV1Api()
+
+    storage = render_j2_template(TEMPLATE_DIR, STORAGE_TEMPLATE, storage_class=storage_class)
+    reading_pod = render_j2_template(
+        TEMPLATE_DIR, READING_POD_TEMPLATE, storage_class=storage_class
+    )
+    reading_pod_name = reading_pod["metadata"]["name"]
+    writing_pod = render_j2_template(
+        TEMPLATE_DIR, WRITING_POD_TEMPLATE, storage_class=storage_class, data=test_payload
+    )
+    writing_pod_name = writing_pod["metadata"]["name"]
+
+    logger.info("Creating PersistentVolumeClaim %s", storage["metadata"]["name"])
+    utils.create_from_dict(k8s_api_client, storage)
+
+    logger.info("Creating Pod %s", writing_pod_name)
+    utils.create_from_dict(k8s_api_client, writing_pod)
+    wait_for_pod(core_api, writing_pod_name, namespace, target_state=SUCCESS_POD_STATE)
+
+    logger.info("Creating Pod %s", reading_pod_name)
+    utils.create_from_dict(k8s_api_client, reading_pod)
+    wait_for_pod(core_api, reading_pod_name, namespace, target_state=SUCCESS_POD_STATE)
+
+    pod_log = core_api.read_namespaced_pod_log(reading_pod_name, namespace)
+    assert test_payload in pod_log, "Pod {} failed to read data written by pod {}".format(
+        reading_pod_name, writing_pod_name
+    )

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Martin Kalcok
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+import pytest
+from pytest_operator.plugin import OpsTest
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test):
+    ceph_csi_charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(ops_test.render_bundle(
+        "tests/functional/bundle.yaml", master_charm=ceph_csi_charm))
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60, check_freq=5, raise_on_error=False)
+
+
+async def test_active_status(ops_test: OpsTest):
+    for unit in ops_test.model.applications["ceph-csi"].units:
+        assert unit.workload_status == "active"
+        assert unit.workload_status_message == "Unit is ready"

--- a/tests/functional/utils/__init__.py
+++ b/tests/functional/utils/__init__.py
@@ -1,0 +1,1 @@
+from .utils import render_j2_template, wait_for_pod

--- a/tests/functional/utils/utils.py
+++ b/tests/functional/utils/utils.py
@@ -1,0 +1,66 @@
+# Copyright 2021 Martin Kalcok
+# See LICENSE file for licensing details.
+"""Various helper functions used by functional tests."""
+
+import logging
+from typing import Any
+
+import pytest
+import yaml
+from jinja2 import Environment, FileSystemLoader
+from kubernetes import client, watch
+
+logger = logging.getLogger(__name__)
+
+
+def render_j2_template(template_dir: str, template: str, **context: Any) -> dict:
+    """Render jinja2 template with provided context.
+
+    :param template_dir: Directory in which the template file is located.
+    :param template: Template file name
+    :param context: variables and their values used in the template.
+    :return: dict parsed from rendered jinja2 template
+    """
+    env = Environment(loader=FileSystemLoader(template_dir))
+    raw_data = env.get_template(template).render(**context)
+    return yaml.safe_load(raw_data)
+
+
+def wait_for_pod(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    timeout: int = 60,
+    target_state: str = "Running",
+) -> None:
+    """
+    Wait for kubernetes pod to reach desired state.
+
+    If the state is not reached within specified timeout, pytest.fail is executed.
+
+    :param core_api: instance of CoreV1 kubernetes api.
+    :param name: name of the kubernetes pod.
+    :param namespace: namespace in which the pod is running
+    :param timeout: Maximum seconds to wait for pod to reach target_state
+    :param target_state: Expected pod status. (e.g.: Running or Succeeded)
+    :return: None
+    """
+    k8s_watch = watch.Watch()
+
+    logger.info("Waiting for pod '%s' to reach state '%s'", name, target_state)
+    for event in k8s_watch.stream(
+        func=core_api.list_namespaced_pod, namespace=namespace, timeout_seconds=timeout
+    ):
+        resource = event["object"]
+        if resource.metadata.name != name:
+            continue
+        pod_state = resource.status.phase
+        logger.debug("%s state: %s", name, pod_state)
+        if pod_state == target_state:
+            break
+    else:
+        pytest.fail(
+            "Timeout after {}s while waiting for {} pod to reach {} status".format(
+                timeout, name, target_state
+            )
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -63,6 +63,28 @@ class TestCharm(unittest.TestCase):
         dict_copy = self.harness.charm.copy_stored_dict(self.harness.charm._stored.ceph_data)
         self.assertEqual(dict_copy, expected_dict)
 
+    def test_ceph_context_getter(self):
+        """Test that ceph_context property returns properly formatted data."""
+        fsid = "12345"
+        key = "secret_key"
+        monitors = "10.0.0.1 10.0.0.2"
+        expected_monitors_format = json.dumps(monitors.split())
+
+        # data from ceph-mon:admin relation
+        relation_data = {"fsid": fsid, "key": key, "mon_hosts": monitors}
+
+        for id_, value in relation_data.items():
+            self.harness.charm._stored.ceph_data[id_] = value
+
+        # key and value format expected in context for Kubernetes templates.
+        expected_context = {
+            "fsid": fsid,
+            "kubernetes_key": key,
+            "mon_hosts": expected_monitors_format,
+        }
+
+        self.assertEqual(self.harness.charm.ceph_context, expected_context)
+
     def test_k8s_resources_getter(self):
         """Test that property 'resources' returns expected list of resources"""
         api_mock = MagicMock()

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,11 @@ commands =
     coverage run --source={toxinidir}/src -m unittest discover {toxinidir}/tests/unit/
     coverage report -m --fail-under=100
 
+[testenv:func]
+basepython = python3
+deps = -r{toxinidir}/requirements-test.txt
+commands = pytest {toxinidir}/tests/functional/ {posargs}
+
 [testenv:format-code]
 envdir = {toxworkdir}/lint
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ basepython = python3
 commands =
     flake8 {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
     pylint {toxinidir}/src/ {toxinidir}/lib/
-    pylint {toxinidir}/tests/ --disable=W0212,R0801,R0201
+    pylint {toxinidir}/tests/ --disable=W0212,R0801,R0201,W0613
     mypy --namespace-packages {toxinidir}/src/ {toxinidir}/lib/
     black -l 99 --check {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
     isort --check {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
@@ -32,6 +32,10 @@ commands =
 
 [testenv:func]
 basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}/tests/functional/
+passenv =
+    TEST_HTTPS_PROXY
 deps = -r{toxinidir}/requirements-test.txt
 commands = pytest {toxinidir}/tests/functional/ {posargs}
 


### PR DESCRIPTION
This change is mainly about functional tests but there's also one implementation change. Due to the fact that raw data from `ceph-mon:admin` relation require some logic to properly format into data that's useful for k8s templates, I added property `ceph_context` that performs this logic.

There's also a potential race condition due to #4 which may cause relation `ceph-csi <-> ceph-mon:admin` to not form correctly if that relation does not contain all the required data at the time when it's formed. This will be addressed, however for now the functional tests pass on properly deployed testing bundle. Current workaround is to remove and re-add `ceph-csi ceph-mon:admin` relation after `ceph-mon` units are in `active/ready` state.

Closes #6 