### PR TITLE
Add handler for change in ceph-mon:admin relation

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -30,8 +30,12 @@ async def kube_config(ops_test: OpsTest) -> Path:
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         kube_config_file = Path(tmp_dir).joinpath("kube_config")
+        # This split is needed because `model_name` gets reported in format "<controller>:<model>"
+        model_name = ops_test.model_name.split(":", maxsplit=1)[-1]
 
-        cmd = "juju scp {}:config {}".format(k8s_master.name, kube_config_file).split()
+        cmd = "juju scp -m {} {}:config {}".format(
+            model_name, k8s_master.name, kube_config_file
+        ).split()
         return_code, _, std_err = await ops_test.run(*cmd)
         assert return_code == 0, std_err
         yield kube_config_file

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -27,7 +27,7 @@ class TestResourceBaseClass(unittest.TestCase):
     """Tests for resource.Resource base class."""
 
     def test_remove_action_props_not_implemented(self):
-        """Test that base class does not have any remove action getters implemented."""
+        """Test that base class does not have any "remove action" getters implemented."""
         resource = Resource("foo")
 
         with self.assertRaises(MissingMethod):
@@ -64,6 +64,49 @@ class TestResourceBaseClass(unittest.TestCase):
 
             resource.remove()
         mock_action.assert_called_once_with(name)
+
+    def test_update_action_props_not_implemented(self):
+        """Test that base class does not have any "update action" getters implemented."""
+        resource = Resource("foo")
+
+        with self.assertRaises(MissingMethod):
+            _ = resource._update_action
+
+        with self.assertRaises(MissingMethod):
+            _ = resource._update_namespaced_action
+
+    def test_update_namespaced_resource(self):
+        """Test that resource with namespace will call namespaced update function."""
+        mock_action = MagicMock()
+        name = "foo"
+        namespace = "bar"
+        update_body = {"property": "new_value"}
+
+        with patch.object(
+            Resource, "_update_namespaced_action", new_callable=PropertyMock
+        ) as action_getter_mock:
+            action_getter_mock.return_value = mock_action
+            resource = Resource(name=name, namespace=namespace)
+
+            resource.update(update_body)
+
+        mock_action.assert_called_once_with(name, namespace, body=update_body)
+
+    def test_update_global_resource(self):
+        """Test that resource without namespace calls global update function."""
+        mock_action = MagicMock()
+        name = "foo"
+        update_body = {"property": "new_value"}
+
+        with patch.object(
+            Resource, "_update_action", new_callable=PropertyMock
+        ) as action_getter_mock:
+            action_getter_mock.return_value = mock_action
+            resource = Resource(name=name)
+
+            resource.update(update_body)
+
+        mock_action.assert_called_once_with(name, body=update_body)
 
     def test_resource_equal(self):
         """Test cases in which two Resource instances should compare equal."""
@@ -112,8 +155,17 @@ class TestResourceActions(unittest.TestCase):
     def setUp(self):
         self.res_name = "foo"
         self.res_namespace = "bar"
+        self.update_data = {"prop": "new_value"}
         self.api_mock = MagicMock()
         self.remove_action_mock = MagicMock()
+        self.update_action_mock = MagicMock()
+
+    def patch(self, obj, method) -> MagicMock:
+        """Method mock scoped to the duration of single unit test."""
+        _patch = patch.object(obj, method)
+        mock_method = _patch.start()
+        self.addCleanup(_patch.stop)
+        return mock_method
 
     def test_secret_removal(self):
         """Test that removing Secret resource calls appropriate api method."""
@@ -123,6 +175,30 @@ class TestResourceActions(unittest.TestCase):
         secret.remove()
 
         self.remove_action_mock.assert_called_once_with(self.res_name, self.res_namespace)
+
+    def test_secret_update(self):
+        """Test that updating Secret resource calls appropriate api method."""
+        self.api_mock.patch_namespaced_secret = self.update_action_mock
+
+        secret = Secret(self.api_mock, self.res_name, self.res_namespace)
+        secret.update(self.update_data)
+
+        self.update_action_mock.assert_called_once_with(
+            self.res_name, self.res_namespace, body=self.update_data
+        )
+
+    def test_secret_update_opaque_data(self):
+        """Test that `Secret.update_opaque_data` calls update method properly."""
+        property_to_update = "userKey"
+        new_data = "newSecretKey"
+        expected_patch = {"stringData": {property_to_update: new_data}}
+
+        update_mock = self.patch(Secret, "update")
+
+        secret = Secret(self.api_mock, self.res_name, self.res_namespace)
+        secret.update_opaque_data(property_to_update, new_data)
+
+        update_mock.assert_called_once_with(expected_patch)
 
     def test_service_removal(self):
         """Test that removing Service resource calls appropriate api method."""
@@ -150,6 +226,29 @@ class TestResourceActions(unittest.TestCase):
         config_map.remove()
 
         self.remove_action_mock.assert_called_once_with(self.res_name, self.res_namespace)
+
+    def test_config_map_update(self):
+        """Test that updating ConfigMap resource calls appropriate api method."""
+        self.api_mock.patch_namespaced_config_map = self.update_action_mock
+
+        config_map = ConfigMap(self.api_mock, self.res_name, self.res_namespace)
+        config_map.update(self.update_data)
+
+        self.update_action_mock.assert_called_once_with(
+            self.res_name, self.res_namespace, body=self.update_data
+        )
+
+    def test_config_map_update_json(self):
+        """Test that `ConfigMap.update_config_json` calls update method properly."""
+        new_config = "new_data"
+        expected_patch = {"data": {"config.json": new_config}}
+
+        update_mock = self.patch(ConfigMap, "update")
+
+        config_map = ConfigMap(self.api_mock, self.res_name, self.res_namespace)
+        config_map.update_config_json(new_config)
+
+        update_mock.assert_called_once_with(expected_patch)
 
     def test_cluster_role_removal(self):
         """Test that removing ClusterRole resource calls appropriate api method."""
@@ -195,6 +294,27 @@ class TestResourceActions(unittest.TestCase):
         storage_class.remove()
 
         self.remove_action_mock.assert_called_once_with(self.res_name)
+
+    def test_storage_class_update(self):
+        """Test that updating StorageClass resource calls appropriate api method."""
+        self.api_mock.patch_storage_class = self.update_action_mock
+
+        storage_class = StorageClass(self.api_mock, self.res_name)
+        storage_class.update(self.update_data)
+
+        self.update_action_mock.assert_called_once_with(self.res_name, body=self.update_data)
+
+    def test_storage_class_update_cluster_id(self):
+        """Test that `StorageClass.update_cluster_id` calls update method properly."""
+        new_id = "new_id"
+        expected_patch = {"parameters": {"clusterID": new_id}}
+
+        update_mock = self.patch(StorageClass, "update")
+
+        storage_class = StorageClass(self.api_mock, self.res_name)
+        storage_class.update_cluster_id(new_id)
+
+        update_mock.assert_called_once_with(expected_patch)
 
     def test_deployment_removal(self):
         """Test that removing Deployment resource calls appropriate api method."""

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ basepython = python3
 commands =
     flake8 {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
     pylint {toxinidir}/src/ {toxinidir}/lib/
-    pylint {toxinidir}/tests/ --disable=W0212,R0801,R0201,W0613
+    pylint {toxinidir}/tests/ --disable=W0212,R0801,R0201,W0613,R0904
     mypy --namespace-packages {toxinidir}/src/ {toxinidir}/lib/
     black -l 99 --check {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/
     isort --check {toxinidir}/src/ {toxinidir}/tests/ {toxinidir}/lib/


### PR DESCRIPTION
Main change was adding a handler for `ceph-mon:admin` relation change. Execution of this handler has two possible outcomes:

- If k8s resources are already created, only resources which depend on data from `ceph-admin` relation will be updated (using `patch_*` method from k8s api)
- If none of the resources are created yet, this handler behaves similar as `_on_ceph_admin_joined` and it will create all the k8s resources. This scenario can happen if `ceph-mon:admin` relation does not have all the required data during the `joining` event, and they become available only later.