### PR TITLE
Update StorageClass without removing it.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -139,9 +139,9 @@ class CephCsiCharm(CharmBase):
     def resources(self) -> List[Resource]:
         """Return list of k8s resources tied to the ceph-csi charm.
 
-        Returned list contains instances that inherit from `Resource` class
-        which provides convenience method `remove()` that removes resources
-        from cluster or namespace.
+        Returned list contains instances that inherit from `Resource` class which provides
+        convenience methods to work with Kubernetes resources.
+        Each instance in the list maps to a specific resources in Kubernetes cluster.
 
         Example:
             for resource in self.resources:
@@ -440,7 +440,7 @@ class CephCsiCharm(CharmBase):
                 self.update_default_storage_class(default_class)
             except ValueError:
                 self.unit.status = BlockedStatus(
-                    "{} 'default-storage'. See logs for more info.'".format(BAD_CONFIG_PREFIX)
+                    "{} 'default-storage'. See logs for more info.".format(BAD_CONFIG_PREFIX)
                 )
                 return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -52,6 +52,9 @@ from ops.model import ActiveStatus, BlockedStatus, Relation, Unit, WaitingStatus
 logger = logging.getLogger(__name__)
 
 
+UNIT_READY_STATUS = ActiveStatus("Unit is ready")
+
+
 def needs_leader(func: Callable) -> Callable:
     """Ensure that function with this decorator is executed only if on leader units."""
 
@@ -217,7 +220,7 @@ class CephCsiCharm(CharmBase):
                 "Missing relations: {}".format(", ".join(missing_relations))
             )
         else:
-            self.unit.status = ActiveStatus("Unit is ready")
+            self.unit.status = UNIT_READY_STATUS
 
     @needs_leader
     def create_ceph_resources(self, resources: List[Dict]) -> None:  # pylint: disable=R0201
@@ -277,14 +280,33 @@ class CephCsiCharm(CharmBase):
         return self.render_resource_definitions() + self.render_storage_definitions()
 
     @needs_leader
-    def update_storage_classes(self) -> None:
-        """Re-render templates and update StorageClass resources in k8s cluster."""
-        logger.info("Updating StorageClass definitions in Kubernetes.")
-        for resource in self.resources:
-            if isinstance(resource, StorageClass):
-                resource.remove()
-        storage_classes = self.render_storage_definitions()
-        self.create_ceph_resources(storage_classes)
+    def update_default_storage_class(self, default_class_name: str) -> None:
+        """Set selected StorageClass as a default option."""
+        available_classes = [sc for sc in self.resources if isinstance(sc, StorageClass)]
+
+        # Find StorageClass that matches `default_class_name`
+        try:
+            default_class = [sc for sc in available_classes if sc.name == default_class_name][0]
+        except IndexError as exc:
+            error_msg = (
+                "Unexpected config value for 'default-storage'. "
+                "Valid values: {}. Got: {}".format(
+                    [sc.name for sc in available_classes], default_class_name
+                )
+            )
+            logger.error(error_msg)
+            raise ValueError(error_msg) from exc
+
+        logger.info("Setting '%s' StorageClass as default.", default_class_name)
+
+        # according to documentation, proper way to set new default SC is to first unset current
+        # default StorageClass and then set the new default.
+        # https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
+        for storage_class in available_classes:
+            if storage_class.name != default_class_name:
+                storage_class.set_default(False)
+
+        default_class.set_default(True)
 
     @needs_leader
     def safe_load_ceph_admin_data(self, relation: Relation, remote_unit: Unit) -> bool:
@@ -411,11 +433,20 @@ class CephCsiCharm(CharmBase):
     def _on_config_changed(self, _: ConfigChangedEvent) -> None:
         """Handle configuration Change."""
         if self.update_stored_state("default-storage", "default_storage_class"):
-            logger.info(
-                "Config changed. New value: 'default-storage' = '%s'",
-                self.config.get("default-storage"),
-            )
-            self.update_storage_classes()
+            default_class = self.config.get("default-storage")
+            logger.info("Config changed. New value: 'default-storage' = '%s'", default_class)
+            try:
+                self.update_default_storage_class(default_class)
+            except ValueError:
+                self.unit.status = BlockedStatus(
+                    "Bad configuration option for 'default-storage'. See logs for more info.'"
+                )
+                return
+
+        # Resolve blocked state caused by bad configuration
+        status = self.unit.status
+        if status.name == BlockedStatus.name and status.message.startswith("Bad configuration"):
+            self.unit.status = UNIT_READY_STATUS
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 
 
 UNIT_READY_STATUS = ActiveStatus("Unit is ready")
+BAD_CONFIG_PREFIX = "Bad configuration option for"
 
 
 def needs_leader(func: Callable) -> Callable:
@@ -439,13 +440,13 @@ class CephCsiCharm(CharmBase):
                 self.update_default_storage_class(default_class)
             except ValueError:
                 self.unit.status = BlockedStatus(
-                    "Bad configuration option for 'default-storage'. See logs for more info.'"
+                    "{} 'default-storage'. See logs for more info.'".format(BAD_CONFIG_PREFIX)
                 )
                 return
 
         # Resolve blocked state caused by bad configuration
         status = self.unit.status
-        if status.name == BlockedStatus.name and status.message.startswith("Bad configuration"):
+        if status.name == BlockedStatus.name and status.message.startswith(BAD_CONFIG_PREFIX):
             self.unit.status = UNIT_READY_STATUS
 
 

--- a/src/resource.py
+++ b/src/resource.py
@@ -288,6 +288,17 @@ class StorageClass(StorageResource):
         """Update clusterID."""
         self.update({"parameters": {"clusterID": id_}})
 
+    def set_default(self, is_default: bool = True) -> None:
+        """Set default status of the StorageClass."""
+        patch = {
+            "metadata": {
+                "annotations": {
+                    "storageclass.kubernetes.io/is-default-class": str(is_default).lower()
+                }
+            }
+        }
+        self.update(patch)
+
 
 class Deployment(AppsResource):
     """Kubernetes 'Deployment' resource."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,6 +26,7 @@ from kubernetes.client import ApiException
 from ops.testing import Harness
 
 from charm import (
+    BAD_CONFIG_PREFIX,
     UNIT_READY_STATUS,
     ActiveStatus,
     BlockedStatus,
@@ -329,7 +330,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"default-storage": bad_storage})
 
         self.assertEqual(self.harness.charm.unit.status.name, BlockedStatus.name)
-        self.assertTrue(self.harness.charm.unit.status.message.startswith("Bad configuration"))
+        self.assertTrue(self.harness.charm.unit.status.message.startswith(BAD_CONFIG_PREFIX))
 
         # reset mocks
         update_default_storage_mock.reset_mock()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -332,7 +332,8 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm.unit.status.message.startswith("Bad configuration"))
 
         # reset mocks
-        update_default_storage_mock.reset_mock(side_effect=True)
+        update_default_storage_mock.reset_mock()
+        update_default_storage_mock.side_effect = None
 
         # Assert that setting valid value for default storage class sets unit status back to Active
         self.harness.update_config({"default-storage": xfs_storage})

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,7 +25,17 @@ from unittest.mock import MagicMock, PropertyMock, call, patch
 from kubernetes.client import ApiException
 from ops.testing import Harness
 
-from charm import CephCsiCharm, CreatePoolConfig, client, config, logger, utils
+from charm import (
+    UNIT_READY_STATUS,
+    ActiveStatus,
+    BlockedStatus,
+    CephCsiCharm,
+    CreatePoolConfig,
+    client,
+    config,
+    logger,
+    utils,
+)
 
 
 class TestCharm(unittest.TestCase):
@@ -220,6 +230,7 @@ class TestCharm(unittest.TestCase):
                 else:
                     self.assertNotIn(default_attribute, annotation)
 
+        self.patch(CephCsiCharm, "update_default_storage_class")
         xfs = self.harness.charm.XFS_STORAGE
         ext4 = self.harness.charm.EXT4_STORAGE
 
@@ -245,31 +256,90 @@ class TestCharm(unittest.TestCase):
         resource_definitions.assert_called_once_with()
         storage_definitions.assert_called_once_with()
 
-    def test_update_storage_class(self):
-        """Test that update_storage_classes() removes old resources and re-adds new resources."""
-        resources = [{"kind": "StorageClass", "metadata": {"name": "sc1"}}]
+    def test_update_default_storage_class(self):
+        """Test that update_default_storage_class() patches StorageClass resources."""
+        ext4_class_update_mock = MagicMock()
+        xfs_class_update_mock = MagicMock()
+        ext4_storage = self.harness.charm.EXT4_STORAGE
+        xfs_storage = self.harness.charm.XFS_STORAGE
+
+        # Setup mock for all expected StorageClasses
+        all_resources = self.harness.charm.resources
+        for resource in all_resources:
+            if isinstance(resource, StorageClass):
+                if resource.name == xfs_storage:
+                    xfs_class_update_mock = self.patch(resource, "set_default")
+                elif resource.name == ext4_storage:
+                    ext4_class_update_mock = self.patch(resource, "set_default")
+                else:
+                    self.fail("Storage class '{}' not covered by unit tests".format(resource.name))
+
+        self.patch_property(CephCsiCharm, "resources").return_value = all_resources
+
+        # Expect no action on non-leader unit
+        self.harness.charm.update_default_storage_class(ext4_storage)
+        self.harness.charm.update_default_storage_class(xfs_storage)
+        self.harness.charm.update_default_storage_class("Foo")
+
+        ext4_class_update_mock.assert_not_called()
+        xfs_class_update_mock.assert_not_called()
+
+        # Set unit as leader and execute actual updates
         self.harness.set_leader(True)
-        remove_storage_mock = self.patch(StorageClass, "remove")
-        render_storage_mock = self.patch(CephCsiCharm, "render_storage_definitions")
-        render_storage_mock.return_value = resources
-        create_resources_mock = self.patch(CephCsiCharm, "create_ceph_resources")
 
-        self.harness.charm.update_storage_classes()
+        # Set ext4 as default storage class
+        self.harness.charm.update_default_storage_class(ext4_storage)
+        ext4_class_update_mock.assert_called_once_with(True)
+        xfs_class_update_mock.assert_called_once_with(False)
 
-        remove_storage_mock.assert_called_with()
-        create_resources_mock.assert_called_with(resources)
+        # reset mocks
+        ext4_class_update_mock.reset_mock()
+        xfs_class_update_mock.reset_mock()
 
-        # Test that nothing is executed on non-leader units
-        self.harness.set_leader(False)
-        remove_storage_mock.reset_mock()
-        render_storage_mock.reset_mock()
-        create_resources_mock.reset_mock()
+        # Set xfs as default storage class
+        self.harness.charm.update_default_storage_class(xfs_storage)
+        ext4_class_update_mock.assert_called_once_with(False)
+        xfs_class_update_mock.assert_called_once_with(True)
 
-        self.harness.charm.update_storage_classes()
+        # Set unknown default storage class
+        with self.assertRaises(ValueError):
+            self.harness.charm.update_default_storage_class("Foo")
 
-        remove_storage_mock.assert_not_called()
-        render_storage_mock.assert_not_called()
-        create_resources_mock.assert_not_called()
+    def test_update_config(self):
+        """Test handling of charm config updates."""
+        update_default_storage_mock = self.patch(CephCsiCharm, "update_default_storage_class")
+        update_stored_state_mock = self.patch(CephCsiCharm, "update_stored_state")
+
+        update_stored_state_mock.return_value = True
+
+        # Update default storage class
+        ext4_storage = self.harness.charm.EXT4_STORAGE
+        xfs_storage = self.harness.charm.XFS_STORAGE
+        bad_storage = "foo"
+
+        self.harness.update_config({"default-storage": ext4_storage})
+
+        update_default_storage_mock.assert_called_once_with(ext4_storage)
+
+        # reset mocks
+        update_default_storage_mock.reset_mock()
+
+        # Update default storage class with bad value and assert that it sets Blocked state
+        update_default_storage_mock.side_effect = ValueError
+        self.harness.update_config({"default-storage": bad_storage})
+
+        self.assertEqual(self.harness.charm.unit.status.name, BlockedStatus.name)
+        self.assertTrue(self.harness.charm.unit.status.message.startswith("Bad configuration"))
+
+        # reset mocks
+        update_default_storage_mock.reset_mock(side_effect=True)
+
+        # Assert that setting valid value for default storage class sets unit status back to Active
+        self.harness.update_config({"default-storage": xfs_storage})
+
+        update_default_storage_mock.assert_called_once_with(xfs_storage)
+        self.assertEqual(self.harness.charm.unit.status.name, ActiveStatus.name)
+        self.assertEqual(self.harness.charm.unit.status.message, UNIT_READY_STATUS.message)
 
     def test_resource_removal(self):
         """Test removal of the k8s resources that happens when ceph-mon relation is removed."""

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -20,7 +20,7 @@ from resource import (
     ServiceAccount,
     StorageClass,
 )
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 
 class TestResourceBaseClass(unittest.TestCase):
@@ -315,6 +315,27 @@ class TestResourceActions(unittest.TestCase):
         storage_class.update_cluster_id(new_id)
 
         update_mock.assert_called_once_with(expected_patch)
+
+    def test_storage_class_set_default(self):
+        """Test that `StorageClass.set_default` calls update method properly."""
+
+        def get_patch(is_default: bool) -> dict:
+            return {
+                "metadata": {
+                    "annotations": {
+                        "storageclass.kubernetes.io/is-default-class": str(is_default).lower()
+                    }
+                }
+            }
+
+        update_mock = self.patch(StorageClass, "update")
+        expected_calls = [call(get_patch(True)), call(get_patch(False))]
+
+        storage_class = StorageClass(self.api_mock, self.res_name)
+        storage_class.set_default(True)
+        storage_class.set_default(False)
+
+        update_mock.assert_has_calls(expected_calls)
 
     def test_deployment_removal(self):
         """Test that removing Deployment resource calls appropriate api method."""


### PR DESCRIPTION
Previously, updates to default storage class were handled by removing all `StorageClasses` and re-adding them with new config values. Aside from not being very elegant, this approach is also bad because it's not possible to remove `StorageClass` that has associated `PersistentVolumeClaim`